### PR TITLE
Fix issue merging KiCAD VRML files.

### DIFF
--- a/make_single_file.php
+++ b/make_single_file.php
@@ -59,7 +59,7 @@ function replace_wrl($file) {
 
     // @todo: this code will also include Inline wrl files that are commented out (if the files can be found), it might be hard to keep those out.
     $content = preg_replace_callback(
-        '/Inline\s?{\s+?url\s+?\["([^"]*)"\]\s+?}/i',
+        '/Inline\s*{\s*url\s+"([^"]*)"\s*}/ism',
         function($matches) use ($path) {
             $filename =  $matches[1];
 //            if ($filename === 'boven/boven.wrl') {
@@ -72,7 +72,7 @@ function replace_wrl($file) {
 //            }
             $output = replace_wrl($path . DIRECTORY_SEPARATOR . $filename);
             // mark beginning and end of original include with the filename
-            $output = '# ' . $filename . PHP_EOL . PHP_EOL . $output . PHP_EOL . PHP_EOL . '# /' . $filename;
+            $output = '# ' . $filename . PHP_EOL . PHP_EOL . $output . PHP_EOL . PHP_EOL . '# /' . $filename . PHP_EOL;
             return $output;
         }
         ,


### PR DESCRIPTION
This fixes two issues when merging VRML files generated by KiCAD.  The first is the change to the regex to allow it to match multi-line entries.  The second change adds a newline to prevent a trailing closing brace from being commented out.

I should note that it also removes two extraneous bracket characters from the regex.  If those are really needed, the regex should be:

`        '/Inline\s*{\s*url\s*\[?\s*"([^"]*)"\s*\]?\s*}/ism',`
